### PR TITLE
Atualiza versão do markdown linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           npm install -g markdownlint-cli
       - name: Set up problem matcher
-        uses: xt0rted/markdownlint-problem-matcher@v1
+        uses: xt0rted/markdownlint-problem-matcher@v2
       - name: Run markdown linter
         run: |
           markdownlint **/*.md --ignore node_modules --config .github/markdownlint.yml


### PR DESCRIPTION
Resolve aviso de node.js 12 descontinuado.

Vide xt0rted/markdownlint-problem-matcher#527